### PR TITLE
Add missing run_export to libitk recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,9 @@ source:
   sha256: 6022b2b64624b8bcec3333fe48d5f74ff6ebceb3bdf98258ba7d7fbbc76b99ab
 
 build:
-  number: 1
+  run_exports:
+    - {{ pin_subpackage('libitk', min_pin='x.x', max_pin='x.x') }}
+  number: 2
   skip: true  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
Packages which vend shared libraries to be build against should include a run-export. For this particular library, packages built against it need the same major.minor version because otherwise, the library name changes.

This was also mentioned https://github.com/conda-forge/libitk-feedstock/pull/41#issuecomment-557814232, but never acted on AFAIK.

https://conda-forge.org/docs/maintainer/pinning_deps.html#specifying-run-exports